### PR TITLE
Move broccoli-webpack from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "broccoli-asset-rev": "^2.4.5",
     "broccoli-funnel": "^1.1.0",
     "broccoli-merge-trees": "^2.0.0",
-    "broccoli-webpack": "^1.0.0",
     "dotenv": "^4.0.0",
     "ember-ajax": "^3.0.0",
     "ember-cli": "2.13.2",
@@ -72,6 +71,7 @@
     "auth0-js": "^8.2.0",
     "auth0-lock": "^10.10.1",
     "auth0-lock-passwordless": "^2.2.3",
+    "broccoli-webpack": "^1.0.0",
     "ember-cli-babel": "^6.0.0",
     "ember-simple-auth": "^1.3.0",
     "rsvp": "^3.3.3"


### PR DESCRIPTION
Closes #79 -- I missed this since my own test-case project was already pulling in `broccoli-webpack` from elsewhere.