### PR TITLE
use either caret or >= but not both

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "repository": "https://github.com/seawatts/ember-simple-auth-auth0",
   "engines": {
-    "node": ">= ^4.0.0"
+    "node": ">= 4.0.0"
   },
   "author": "seawatts",
   "license": "MIT",


### PR DESCRIPTION
I switched from [npm](https://www.npmjs.com/) to [yarn](https://yarnpkg.com/en/) because of [Dependabot](https://dependabot.com/), see @greysteil's [comment](https://github.com/roschaefer/rundfunk-mitbestimmen/pull/250#issuecomment-327808571).

When I `yarn install` I see:
```
➜  frontend git:(6ce2cc7) ✗ yarn install
yarn install v1.0.0
[1/5] Validating package.json...
[2/5] Resolving packages...
[3/5] Fetching packages...
info fsevents@1.1.2: The platform "linux" is incompatible with this module.
info "fsevents@1.1.2" is an optional dependency and failed compatibility check. Excluding it from installation.
error ember-simple-auth-auth0@3.0.1: The engine "node" is incompatible with this module. Expected version ">= ^4.0.0".
error Found incompatible module
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```

Probably a typo by @seawatts in 4ae718d4c44b8eb5d31257c9332606e23ecf1848

close #78 