### PR TITLE
Use production build of React for production apps

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ const path = require('path');
 const Funnel = require('broccoli-funnel');
 const MergeTrees = require('broccoli-merge-trees');
 const Webpack = require('broccoli-webpack');
+const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
+const wp = require('webpack');
 
 function transformAMD(name) {
   return { using: [{ transformation: 'amd', as: name }] };
@@ -21,7 +23,12 @@ function webpackify(name, dir) {
       filename: name + '.js',
       library: name,
       libraryTarget: 'umd'
-    }
+    },
+    plugins: [
+      new wp.DefinePlugin({
+        'process.env.NODE_ENV': JSON.stringify(EmberAddon.env())
+      })
+    ]
   });
 }
 


### PR DESCRIPTION
Closes #88 

This is marked as a bug rather than an enhancement since React throws a big ugly red error-as-warning if you don't do this. ;)

The environment from Ember is passed in, so you'll get the dev build of React in development builds, which is what we want anyway.