### PR TITLE
Fix "Multiple copies of React" error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 /libpeerconnection.log
 npm-debug.log*
 testem.log
+/DEBUG
 
 # ember-try
 .node_modules.ember-try/

--- a/index.js
+++ b/index.js
@@ -28,7 +28,13 @@ function webpackify(name, dir) {
       new wp.DefinePlugin({
         'process.env.NODE_ENV': JSON.stringify(EmberAddon.env())
       })
-    ]
+    ],
+    resolve: {
+      alias: {
+        'react'    : path.dirname(require.resolve('react')),
+        'react-dom': path.dirname(require.resolve('react-dom')),
+      }
+    }
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "broccoli-asset-rev": "^2.4.5",
     "broccoli-funnel": "^1.1.0",
     "broccoli-merge-trees": "^2.0.0",
+    "broccoli-stew": "^1.5.0",
     "dotenv": "^4.0.0",
     "ember-ajax": "^3.0.0",
     "ember-cli": "~2.13.3",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,8 @@
     "broccoli-webpack": "^1.0.0",
     "ember-cli-babel": "^6.0.0",
     "ember-simple-auth": "^1.3.0",
+    "react": "^0.14.0",
+    "react-dom": "^0.14.0",
     "rsvp": "^3.3.3"
   },
   "ember-addon": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1542,7 +1542,7 @@ broccoli-sri-hash@^2.1.0:
     sri-toolbox "^0.2.0"
     symlink-or-copy "^1.0.1"
 
-broccoli-stew@^1.2.0, broccoli-stew@^1.3.3, broccoli-stew@^1.4.0, broccoli-stew@^1.4.2:
+broccoli-stew@^1.2.0, broccoli-stew@^1.3.3, broccoli-stew@^1.4.0, broccoli-stew@^1.4.2, broccoli-stew@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/broccoli-stew/-/broccoli-stew-1.5.0.tgz#d7af8c18511dce510e49d308a62e5977f461883c"
   dependencies:


### PR DESCRIPTION
Closes #89 

Well, that was an adventure. Spent quite a while trying some webpack workarounds to no avail, then realized that explicitly including the `0.14.x` version of `react` and `react-dom` as dependencies of the addon does the trick.

Everything seems to work just fine with `0.14.x` (at least in all the probably-not-extensive cases I've tried), and the version clash has to be dealt with one way or another until we make the leap to the next Lock version. It's an improvement either way.