### PR TITLE
Fix URL Hash errors

### DIFF
--- a/addon/authenticators/auth0-url-hash.js
+++ b/addon/authenticators/auth0-url-hash.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import Auth0BaseAuthenticator from 'ember-simple-auth-auth0/authenticators/auth0-base';
 import createSessionDataObject from '../utils/create-session-data-object';
+import { Auth0Error } from '../utils/errors'
 
 const {
   RSVP,
@@ -24,7 +25,7 @@ export default Auth0BaseAuthenticator.extend({
 
       getUserInfo(urlHashData.accessToken, (err, profile) => {
         if (err) {
-          return reject(err);
+          return reject(new Auth0Error(err));
         }
 
         resolve(createSessionDataObject(profile, urlHashData));

--- a/addon/mixins/application-route-mixin.js
+++ b/addon/mixins/application-route-mixin.js
@@ -73,13 +73,13 @@ export default Mixin.create(ApplicationRouteMixin, {
       return;
     }
 
-    return get(this, 'session').authenticate('authenticator:auth0-url-hash', urlHashData);
+    return get(this, 'session').authenticate('authenticator:auth0-url-hash', urlHashData)
+      .then(this._clearUrlHash.bind(this));
   },
 
   _getUrlHashData() {
     const auth0 = get(this, 'auth0').getAuth0Instance();
     return new RSVP.Promise((resolve, reject) => {
-      // TODO: Check to see if we cannot parse the hash or check to see which version of auth0 we are using.... ugh
       auth0.parseHash((err, parsedPayload) => {
         if (err) {
           return reject(new Auth0Error(err));
@@ -88,6 +88,13 @@ export default Mixin.create(ApplicationRouteMixin, {
         resolve(parsedPayload);
       });
     });
+  },
+
+  _clearUrlHash() {
+    if(!testing && window.history) {
+      window.history.pushState('', document.title, window.location.pathname + window.location.search);
+    }
+    return RSVP.resolve()
   },
 
   _setupFutureEvents() {

--- a/addon/mixins/application-route-mixin.js
+++ b/addon/mixins/application-route-mixin.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import ApplicationRouteMixin from 'ember-simple-auth/mixins/application-route-mixin';
+import { Auth0Error } from '../utils/errors'
 
 const {
   Mixin,
@@ -81,11 +82,7 @@ export default Mixin.create(ApplicationRouteMixin, {
       // TODO: Check to see if we cannot parse the hash or check to see which version of auth0 we are using.... ugh
       auth0.parseHash((err, parsedPayload) => {
         if (err) {
-          if (err.errorDescription) {
-            err.errorDescription = decodeURI(err.errorDescription);
-          }
-
-          return reject(err);
+          return reject(new Auth0Error(err));
         }
 
         resolve(parsedPayload);

--- a/addon/services/auth0.js
+++ b/addon/services/auth0.js
@@ -3,6 +3,7 @@ import Auth0 from 'auth0';
 import Auth0Lock from 'auth0-lock';
 import Auth0LockPasswordless from 'auth0-lock-passwordless';
 import createSessionDataObject from '../utils/create-session-data-object';
+import { Auth0Error } from '../utils/errors'
 
 const {
   Service,
@@ -86,12 +87,12 @@ export default Service.extend({
     // lock.on('hash_parsed', resolve);
     lock.on('authenticated', (authenticatedData) => {
       if (isEmpty(authenticatedData)) {
-        return reject(new Error('The authenticated data did not come back from the request'));
+        return reject(new Auth0Error('The authenticated data did not come back from the request'));
       }
 
       lock.getUserInfo(authenticatedData.accessToken, (error, profile) => {
         if (error) {
-          return reject(error);
+          return reject(new Auth0Error(error));
         }
 
         resolve(createSessionDataObject(profile, authenticatedData));

--- a/addon/utils/errors.js
+++ b/addon/utils/errors.js
@@ -1,0 +1,24 @@
+import Ember from 'ember';
+
+const { Error: EmberError } = Ember;
+
+export function Auth0Error(payload) {
+  let message = 'Auth0 operation failed'
+
+  if(typeof payload === 'object' && payload !== null) {
+    if (payload.errorDescription) {
+      payload.errorDescription = decodeURI(payload.errorDescription);
+    }
+    const errorCode = payload.error || 'unknown'
+    const errorDesc = payload.errorDescription || message
+    message = `Auth0 returned error \`${errorCode}\`: ${errorDesc}`
+  } else if(typeof payload === 'string') {
+    message += `: ${payload}`
+    payload = {}
+  }
+
+  EmberError.call(this, message);
+  this.payload = payload;
+}
+
+Auth0Error.prototype = Object.create(EmberError.prototype);


### PR DESCRIPTION
Closes #67 

In addition to clearing the hash after authentication (thus fixing the root issue), this also adds better error handling in case something goes belly-up so it's possible to get a real error message.