### PR TITLE
Fix the way _expiresAt is calculated

### DIFF
--- a/addon/mixins/application-route-mixin.js
+++ b/addon/mixins/application-route-mixin.js
@@ -132,7 +132,9 @@ export default Mixin.create(ApplicationRouteMixin, {
 
   _jwtRemainingTimeInSeconds: computed('_expiresAt', {
     get() {
-      return getWithDefault(this, '_expiresAt', 0);
+      let remaining = getWithDefault(this, '_expiresAt', 0) - Math.ceil(Date.now() / 1000);
+
+      return remaining < 0 ? 0 : remaining;
     }
   }),
 

--- a/addon/mixins/application-route-mixin.js
+++ b/addon/mixins/application-route-mixin.js
@@ -119,15 +119,14 @@ export default Mixin.create(ApplicationRouteMixin, {
    */
   _expiresAt: computed('session.data.authenticated', {
     get() {
-      let exp = 0;
-
       if (!get(this, 'session.isAuthenticated')) {
-        return exp;
+        return 0;
       }
 
-      const foo = getWithDefault(this, 'session.data.authenticated.idTokenPayload.exp', exp);
+      let expiresIn = getWithDefault(this, 'session.data.authenticated.expiresIn', 0);
+      let issuedAt = getWithDefault(this, 'session.data.authenticated.idTokenPayload.iat', 0);
 
-      return getWithDefault(this, 'session.data.authenticated.expiresIn', foo);
+      return issuedAt + expiresIn;
     }
   }),
 

--- a/tests/unit/mixins/application-route-mixin-test.js
+++ b/tests/unit/mixins/application-route-mixin-test.js
@@ -31,18 +31,22 @@ moduleFor('mixin:application-route-mixin', 'Unit | Mixin | application route mix
 
 test('it sets the correct expiration time if the expiresIn exists', function(assert) {
   assert.expect(1);
+  const issuedAt = Math.ceil(Date.now() / 1000);
   const subject = this.subject({
     session: {
       isAuthenticated: true,
       data: {
         authenticated: {
           expiresIn: 10,
+          idTokenPayload: {
+            iat: issuedAt
+          }
         },
       },
     },
   });
 
-  assert.equal(get(subject, '_expiresAt'), 10);
+  assert.equal(get(subject, '_expiresAt'), issuedAt + 10);
 });
 
 test('it does not set the exp time if the user is not authenticated', function(assert) {


### PR DESCRIPTION
The session.isAuthenticated was "true" at every page refresh, because the _expiresAt property was calculated in a wrong way. This was causing the app to be always authenticated, even if the access token was expired.

_expiresAt was supposed to be a timestamp at which the token will expire, but instead of this we were returning the "expiresIn" which is the remaining seconds, and after the each page refresh the "_scheduleExpire" method was scheduling the session expiration after an "expiresIn" amount of seconds.

My fix is calculating the _expiresAt based on the formula: "JWT issued timestamp" + "expiresIn". The result will be exactly the expiration timestamp of the accessToken, which will be later used to access the APIs. In conclusion, the session will be valid while the accessToken is.