### PR TITLE
Fix token expiration glitchiness

### DIFF
--- a/addon/authenticators/auth0-base.js
+++ b/addon/authenticators/auth0-base.js
@@ -1,5 +1,7 @@
 import Ember from 'ember';
 import BaseAuthenticator from 'ember-simple-auth/authenticators/base';
+import getSessionExpiration from '../utils/get-session-expiration';
+import now from '../utils/now';
 
 const {
   RSVP,
@@ -11,6 +13,11 @@ const {
 export default BaseAuthenticator.extend({
   auth0: service(),
   restore(data) {
-    return RSVP.resolve(data);
+    const expiresAt = getSessionExpiration(data || {});
+    if(expiresAt > now()) {
+      return RSVP.resolve(data);
+    } else {
+      return RSVP.reject();
+    }
   },
 });

--- a/addon/mixins/application-route-mixin.js
+++ b/addon/mixins/application-route-mixin.js
@@ -125,20 +125,17 @@ export default Mixin.create(ApplicationRouteMixin, {
         return 0;
       }
 
-      let issuedAt;
-      let expiresIn;
-
       const idTokenPayload = get(this, 'session.data.authenticated.idTokenPayload');
 
       if(idTokenPayload) {
-        issuedAt = getWithDefault(idTokenPayload, 'iat', 0);
-        expiresIn = getWithDefault(idTokenPayload, 'exp', 0);
-      } else {
-        issuedAt = getWithDefault(this, 'session.data.authenticated.issuedAt', 0);
-        expiresIn = getWithDefault(this, 'session.data.authenticated.expiresIn', 0);
-      }
+        return getWithDefault(idTokenPayload, 'exp', 0);
 
-      return issuedAt + expiresIn;
+      } else {
+        const issuedAt = getWithDefault(this, 'session.data.authenticated.issuedAt', 0);
+        const expiresIn = getWithDefault(this, 'session.data.authenticated.expiresIn', 0);
+
+        return issuedAt + expiresIn;
+      }
     }
   }),
 

--- a/addon/mixins/application-route-mixin.js
+++ b/addon/mixins/application-route-mixin.js
@@ -124,8 +124,18 @@ export default Mixin.create(ApplicationRouteMixin, {
         return 0;
       }
 
-      let expiresIn = getWithDefault(this, 'session.data.authenticated.expiresIn', 0);
-      let issuedAt = getWithDefault(this, 'session.data.authenticated.idTokenPayload.iat', 0);
+      let issuedAt;
+      let expiresIn;
+
+      const idTokenPayload = get(this, 'session.data.authenticated.idTokenPayload');
+
+      if(idTokenPayload) {
+        issuedAt = getWithDefault(idTokenPayload, 'iat', 0);
+        expiresIn = getWithDefault(idTokenPayload, 'exp', 0);
+      } else {
+        issuedAt = get(this, '_now');
+        expiresIn = getWithDefault(this, 'session.data.authenticated.expiresIn', 0);
+      }
 
       return issuedAt + expiresIn;
     }
@@ -133,9 +143,15 @@ export default Mixin.create(ApplicationRouteMixin, {
 
   _jwtRemainingTimeInSeconds: computed('_expiresAt', {
     get() {
-      let remaining = getWithDefault(this, '_expiresAt', 0) - Math.ceil(Date.now() / 1000);
+      let remaining = getWithDefault(this, '_expiresAt', 0) - get(this, '_now');
 
       return remaining < 0 ? 0 : remaining;
+    }
+  }),
+
+  _now: computed({
+    get() {
+      return Math.ceil(Date.now() / 1000);
     }
   }),
 

--- a/addon/mixins/application-route-mixin.js
+++ b/addon/mixins/application-route-mixin.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import ApplicationRouteMixin from 'ember-simple-auth/mixins/application-route-mixin';
 import { Auth0Error } from '../utils/errors'
+import getSessionExpiration from '../utils/get-session-expiration';
 import now from '../utils/now';
 
 const {
@@ -125,17 +126,8 @@ export default Mixin.create(ApplicationRouteMixin, {
         return 0;
       }
 
-      const idTokenPayload = get(this, 'session.data.authenticated.idTokenPayload');
-
-      if(idTokenPayload) {
-        return getWithDefault(idTokenPayload, 'exp', 0);
-
-      } else {
-        const issuedAt = getWithDefault(this, 'session.data.authenticated.issuedAt', 0);
-        const expiresIn = getWithDefault(this, 'session.data.authenticated.expiresIn', 0);
-
-        return issuedAt + expiresIn;
-      }
+      const sessionData = get(this, 'session.data.authenticated');
+      return getSessionExpiration(sessionData);
     }
   }),
 

--- a/addon/mixins/application-route-mixin.js
+++ b/addon/mixins/application-route-mixin.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import ApplicationRouteMixin from 'ember-simple-auth/mixins/application-route-mixin';
 import { Auth0Error } from '../utils/errors'
+import now from '../utils/now';
 
 const {
   Mixin,
@@ -133,7 +134,7 @@ export default Mixin.create(ApplicationRouteMixin, {
         issuedAt = getWithDefault(idTokenPayload, 'iat', 0);
         expiresIn = getWithDefault(idTokenPayload, 'exp', 0);
       } else {
-        issuedAt = get(this, '_now');
+        issuedAt = getWithDefault(this, 'session.data.authenticated.issuedAt', 0);
         expiresIn = getWithDefault(this, 'session.data.authenticated.expiresIn', 0);
       }
 
@@ -143,15 +144,9 @@ export default Mixin.create(ApplicationRouteMixin, {
 
   _jwtRemainingTimeInSeconds: computed('_expiresAt', {
     get() {
-      let remaining = getWithDefault(this, '_expiresAt', 0) - get(this, '_now');
+      let remaining = getWithDefault(this, '_expiresAt', 0) - now();
 
       return remaining < 0 ? 0 : remaining;
-    }
-  }),
-
-  _now: computed({
-    get() {
-      return Math.ceil(Date.now() / 1000);
     }
   }),
 

--- a/addon/mixins/application-route-mixin.js
+++ b/addon/mixins/application-route-mixin.js
@@ -18,7 +18,6 @@ const {
     service
   },
   run,
-  testing,
   isEmpty,
 } = Ember;
 
@@ -94,7 +93,7 @@ export default Mixin.create(ApplicationRouteMixin, {
   },
 
   _clearUrlHash() {
-    if(!testing && window.history) {
+    if(!Ember.testing && window.history) {
       window.history.pushState('', document.title, window.location.pathname + window.location.search);
     }
     return RSVP.resolve()
@@ -102,7 +101,7 @@ export default Mixin.create(ApplicationRouteMixin, {
 
   _setupFutureEvents() {
     // Don't schedule expired events during testing, otherwise acceptance tests will hang.
-    if (testing) {
+    if (Ember.testing) {
       return;
     }
 

--- a/addon/services/auth0.js
+++ b/addon/services/auth0.js
@@ -14,7 +14,6 @@ const {
   getOwner,
   getProperties,
   assert,
-  testing,
   isEmpty,
   inject: {
     service
@@ -117,7 +116,7 @@ export default Service.extend({
       clientID
     } = getProperties(this, 'domain', 'logoutReturnToURL', 'clientID');
 
-    if (!testing) {
+    if (!Ember.testing) {
       window.location.replace(`https://${domain}/v2/logout?returnTo=${logoutReturnToURL}&client_id=${clientID}`);
     }
   },

--- a/addon/utils/create-session-data-object.js
+++ b/addon/utils/create-session-data-object.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 const assign = Ember.assign || Ember.merge;
 
+import now from '../utils/now';
+
 export default function createSessionDataObject(profile, tokenInfo) {
-  return assign(tokenInfo, { profile });
+  return assign({ issuedAt: now() }, tokenInfo, { profile });
 }

--- a/addon/utils/create-session-data-object.js
+++ b/addon/utils/create-session-data-object.js
@@ -4,5 +4,9 @@ const assign = Ember.assign || Ember.merge;
 import now from '../utils/now';
 
 export default function createSessionDataObject(profile, tokenInfo) {
-  return assign({ issuedAt: now() }, tokenInfo, { profile });
+  // assign things one at a time so it's compatible with the Ember.merge fallback
+  const sessionData = { issuedAt: now() };
+  assign(sessionData, tokenInfo);
+  assign(sessionData, { profile });
+  return sessionData;
 }

--- a/addon/utils/get-session-expiration.js
+++ b/addon/utils/get-session-expiration.js
@@ -1,0 +1,27 @@
+import Ember from 'ember';
+const {
+  get,
+  getWithDefault
+} = Ember;
+
+/**
+ * Get the token expiration time from the specified session data object.
+ * If an ID token is defined, use the `exp` field since it's nice and
+ * well-defined. Otherwise, calculate an expiration time from the
+ * expiresIn field and the time the session object was created.
+ * 
+ * @return {Expiration time of token (Unix timestamp)}
+ */
+export default function getSessionExpiration(sessionData) {
+  const idTokenPayload = get(sessionData, 'idTokenPayload');
+
+  if(idTokenPayload) {
+    return getWithDefault(idTokenPayload, 'exp', 0);
+
+  } else {
+    const issuedAt = getWithDefault(sessionData, 'issuedAt', 0);
+    const expiresIn = getWithDefault(sessionData, 'expiresIn', 0);
+
+    return issuedAt + expiresIn;
+  }
+}

--- a/addon/utils/now.js
+++ b/addon/utils/now.js
@@ -1,0 +1,3 @@
+export default function now() {
+  return Math.ceil(Date.now() / 1000);
+}

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",
+    "ember-mockdate-shim": "^0.1.0",
     "ember-moment": "^7.3.1",
     "ember-qunit-nice-errors": "1.1.2",
     "ember-resolver": "^4.0.0",

--- a/test-support/helpers/ember-simple-auth-auth0.js
+++ b/test-support/helpers/ember-simple-auth-auth0.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import createSessionDataObject from 'ember-simple-auth-auth0/utils/create-session-data-object';
 
 const {
   RSVP,
@@ -11,19 +12,8 @@ export function mockAuth0Lock(app, sessionData) {
   set(auth0, 'test_showLock', auth0.showLock.bind(auth0));
 
   auth0.showLock = function() {
-    return RSVP.resolve(sessionData);
+    return RSVP.resolve(createSessionDataObject({}, sessionData));
   }.bind(auth0);
-
-  // TODO: remove this evil hack
-  // [XA] There's a current issue where session expiration isn't handled
-  //      properly in tests, and it's blocking the Lock v11 migration.
-  //      For now, let's zap the invalidation handling and laugh evilly.
-  //      (I'd target _processSessionExpired but I can't lookup the app route:
-  //       see https://github.com/emberjs/ember.js/issues/14716 )
-  //      I'll remove this hack once I fix up the session expiration code,
-  //      so this is very much temporary.
-  const session = container.lookup('service:session');
-  session.invalidate = function() {}
 
   return wait();
 }

--- a/tests/acceptance/routes/login-test.js
+++ b/tests/acceptance/routes/login-test.js
@@ -33,7 +33,8 @@ test('visiting /login redirects to /protected page if authenticated', function(a
 test('it mocks the auth0 lock login and logs in the user', function(assert) {
   assert.expect(2);
   const sessionData = {
-    idToken: 1
+    idToken: 1,
+    expiresIn: 3600
   };
 
   mockAuth0Lock(this.application, sessionData);
@@ -53,7 +54,8 @@ test('it mocks the auth0 lock login and logs in the user', function(assert) {
 test('it mocks the auth0 lock login again and logs in a different user', function(assert) {
   assert.expect(2);
   const sessionData = {
-    idToken: 2
+    idToken: 2,
+    expiresIn: 3600
   };
 
   mockAuth0Lock(this.application, sessionData);

--- a/tests/unit/mixins/application-route-mixin-test.js
+++ b/tests/unit/mixins/application-route-mixin-test.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 import ApplicationRouteMixinMixin from 'ember-simple-auth-auth0/mixins/application-route-mixin';
 import { moduleFor } from 'ember-qunit';
 import test from 'ember-sinon-qunit/test-support/test';
+import now from 'ember-simple-auth-auth0/utils/now';
 
 const {
   get,
@@ -29,17 +30,36 @@ moduleFor('mixin:application-route-mixin', 'Unit | Mixin | application route mix
   }
 });
 
-test('it sets the correct expiration time if the expiresIn exists', function(assert) {
+test('it sets the correct expiration time if the expiresIn header exists', function(assert) {
   assert.expect(1);
-  const issuedAt = Math.ceil(Date.now() / 1000);
+  const issuedAt = now();
   const subject = this.subject({
     session: {
       isAuthenticated: true,
       data: {
         authenticated: {
           expiresIn: 10,
+          issuedAt: issuedAt
+        },
+      },
+    },
+  });
+
+  assert.equal(get(subject, '_expiresAt'), issuedAt + 10);
+});
+
+test('it sets the correct expiration time if the id token exists', function(assert) {
+  assert.expect(1);
+  const issuedAt = now();
+  const subject = this.subject({
+    session: {
+      isAuthenticated: true,
+      data: {
+        authenticated: {
+          expiresIn: 12, // should NOT match
           idTokenPayload: {
-            iat: issuedAt
+            iat: issuedAt,
+            exp: issuedAt + 10
           }
         },
       },

--- a/tests/unit/mixins/application-route-mixin-test.js
+++ b/tests/unit/mixins/application-route-mixin-test.js
@@ -2,6 +2,8 @@ import Ember from 'ember';
 import ApplicationRouteMixinMixin from 'ember-simple-auth-auth0/mixins/application-route-mixin';
 import { moduleFor } from 'ember-qunit';
 import test from 'ember-sinon-qunit/test-support/test';
+
+import { freezeDateAt, unfreezeDate } from 'ember-mockdate-shim';
 import now from 'ember-simple-auth-auth0/utils/now';
 
 const {
@@ -31,6 +33,8 @@ moduleFor('mixin:application-route-mixin', 'Unit | Mixin | application route mix
 });
 
 test('it sets the correct expiration time if the expiresIn header exists', function(assert) {
+  freezeDateAt(new Date('1993-12-10T08:44:00'));
+
   assert.expect(1);
   const issuedAt = now();
   const subject = this.subject({
@@ -46,9 +50,12 @@ test('it sets the correct expiration time if the expiresIn header exists', funct
   });
 
   assert.equal(get(subject, '_expiresAt'), issuedAt + 10);
+  unfreezeDate();
 });
 
 test('it sets the correct expiration time if the id token exists', function(assert) {
+  freezeDateAt(new Date('1993-12-10T08:44:00'));
+
   assert.expect(1);
   const issuedAt = now();
   const subject = this.subject({
@@ -67,6 +74,7 @@ test('it sets the correct expiration time if the id token exists', function(asse
   });
 
   assert.equal(get(subject, '_expiresAt'), issuedAt + 10);
+  unfreezeDate();
 });
 
 test('it does not set the exp time if the user is not authenticated', function(assert) {

--- a/tests/unit/utils/create-session-data-object-test.js
+++ b/tests/unit/utils/create-session-data-object-test.js
@@ -5,12 +5,16 @@ import {
   test
 } from 'qunit';
 
+import now from 'ember-simple-auth-auth0/utils/now';
+
 const assign = Ember.assign || Ember.merge;
 
 module('Unit | Utility | create session data object');
 
 test('it merges the profile and token info', function(assert) {
   assert.expect(1);
+
+  const issuedAt = now();
 
   let profile = {
     my_key: 'foo'
@@ -20,13 +24,15 @@ test('it merges the profile and token info', function(assert) {
     idToken: 'aaa.bbbb.ccc'
   };
 
-  let expectedResult = assign({ profile }, tokenInfo);
+  let expectedResult = assign({ issuedAt: issuedAt }, { profile }, tokenInfo);
   let result = createSessionDataObject(profile, tokenInfo);
   assert.deepEqual(result, expectedResult);
 });
 
 test('it merges the profile and token info, ignoring a previous profile attribute', function(assert) {
   assert.expect(1);
+
+  const issuedAt = now();
 
   let profile = {
     my_key: 'foo'
@@ -38,10 +44,26 @@ test('it merges the profile and token info, ignoring a previous profile attribut
   };
 
   let expectedResult = {
+    issuedAt: issuedAt,
     idToken: 'aaa.bbbb.ccc',
     profile,
   };
 
   let result = createSessionDataObject(profile, tokenInfo);
   assert.deepEqual(result, expectedResult);
+});
+
+test('it issues a creation timestamp', function(assert) {
+  assert.expect(1);
+
+  let profile = {
+    my_key: 'foo'
+  };
+
+  let tokenInfo = {
+    idToken: 'aaa.bbbb.ccc'
+  };
+
+  let result = createSessionDataObject(profile, tokenInfo);
+  assert.ok(result.issuedAt);
 });

--- a/tests/unit/utils/create-session-data-object-test.js
+++ b/tests/unit/utils/create-session-data-object-test.js
@@ -26,7 +26,10 @@ test('it merges the profile and token info', function(assert) {
     idToken: 'aaa.bbbb.ccc'
   };
 
-  let expectedResult = assign({ issuedAt: issuedAt }, { profile }, tokenInfo);
+  let expectedResult = { issuedAt: issuedAt };
+  assign(expectedResult, { profile });
+  assign(expectedResult, tokenInfo);
+
   let result = createSessionDataObject(profile, tokenInfo);
   assert.deepEqual(result, expectedResult);
   unfreezeDate();

--- a/tests/unit/utils/create-session-data-object-test.js
+++ b/tests/unit/utils/create-session-data-object-test.js
@@ -5,6 +5,7 @@ import {
   test
 } from 'qunit';
 
+import { freezeDateAt, unfreezeDate } from 'ember-mockdate-shim';
 import now from 'ember-simple-auth-auth0/utils/now';
 
 const assign = Ember.assign || Ember.merge;
@@ -12,6 +13,7 @@ const assign = Ember.assign || Ember.merge;
 module('Unit | Utility | create session data object');
 
 test('it merges the profile and token info', function(assert) {
+  freezeDateAt(new Date('1993-12-10T08:44:00'));
   assert.expect(1);
 
   const issuedAt = now();
@@ -27,9 +29,11 @@ test('it merges the profile and token info', function(assert) {
   let expectedResult = assign({ issuedAt: issuedAt }, { profile }, tokenInfo);
   let result = createSessionDataObject(profile, tokenInfo);
   assert.deepEqual(result, expectedResult);
+  unfreezeDate();
 });
 
 test('it merges the profile and token info, ignoring a previous profile attribute', function(assert) {
+  freezeDateAt(new Date('1993-12-10T08:44:00'));
   assert.expect(1);
 
   const issuedAt = now();
@@ -51,6 +55,7 @@ test('it merges the profile and token info, ignoring a previous profile attribut
 
   let result = createSessionDataObject(profile, tokenInfo);
   assert.deepEqual(result, expectedResult);
+  unfreezeDate();
 });
 
 test('it issues a creation timestamp', function(assert) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3100,6 +3100,15 @@ ember-macro-helpers@^0.17.0:
     ember-cli-test-info "^1.0.0"
     ember-weakmap "^3.0.0"
 
+ember-mockdate-shim@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/ember-mockdate-shim/-/ember-mockdate-shim-0.1.0.tgz#675bb6b0dda3a08e6bdbccaccd14b408b60925b1"
+  dependencies:
+    broccoli-funnel "^1.2.0"
+    broccoli-merge-trees "^2.0.0"
+    ember-cli-babel "^6.6.0"
+    mockdate "^2.0.1"
+
 ember-moment@^7.3.1:
   version "7.5.0"
   resolved "https://registry.yarnpkg.com/ember-moment/-/ember-moment-7.5.0.tgz#9ed25b32ae941b2f1d9116c44f518a52bdb01722"
@@ -6012,6 +6021,10 @@ mkdirp@^0.3.5:
 mktemp@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/mktemp/-/mktemp-0.4.0.tgz#6d0515611c8a8c84e484aa2000129b98e981ff0b"
+
+mockdate@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-2.0.2.tgz#5ae0c0eaf8fe23e009cd01f9889b42c4f634af12"
 
 moment-timezone@^0.3.0:
   version "0.3.1"


### PR DESCRIPTION
This fixes a few things related to token expiration:

- Session no longer expires instantly when no `id_token` is present (fixes #116 / #114)
- Expired tokens are no longer restored when reloading apps (fixes #75)
- Fixed session expiration causing tests to hang (and removed a workaround I hacked in).

Once this is merged in, I'll cut a `v4.0.1` release.