### PR TITLE
Fix another zero-second-expiration bug

### DIFF
--- a/addon/utils/get-session-expiration.js
+++ b/addon/utils/get-session-expiration.js
@@ -13,10 +13,10 @@ const {
  * @return {Expiration time of token (Unix timestamp)}
  */
 export default function getSessionExpiration(sessionData) {
-  const idTokenPayload = get(sessionData, 'idTokenPayload');
+  const idTokenExpiration = get(sessionData, 'idTokenPayload.exp');
 
-  if(idTokenPayload) {
-    return getWithDefault(idTokenPayload, 'exp', 0);
+  if(idTokenExpiration) {
+    return idTokenExpiration;
 
   } else {
     const issuedAt = getWithDefault(sessionData, 'issuedAt', 0);


### PR DESCRIPTION
Missed a spot. `v4.0.2` incoming once this is merged.