### PR TITLE
Fix failed login causing promise to never resolve

### DIFF
--- a/addon/services/auth0.js
+++ b/addon/services/auth0.js
@@ -61,10 +61,7 @@ export default Service.extend({
   },
 
   _setupLock(lock, resolve, reject) {
-    lock.on('unrecoverable_error', reject);
-    lock.on('authorization_error', reject);
-
-    // lock.on('hash_parsed', resolve);
+    lock.on('hide', reject);
     lock.on('authenticated', (authenticatedData) => {
       if (isEmpty(authenticatedData)) {
         return reject(new Auth0Error('The authenticated data did not come back from the request'));

--- a/tests/unit/services/auth0-test.js
+++ b/tests/unit/services/auth0-test.js
@@ -95,7 +95,7 @@ module('Unit | Service | auth0', function(hooks) {
     stubbedLock.trigger('authenticated', authenticatedData);
   });
 
-  test('showLock rejects when receiving an unrecoverable_error', function(assert) {
+  test('showLock rejects when hidden', function(assert) {
     assert.expect(1);
     const done = assert.async();
     const stubbedLock = new StubLock();
@@ -108,23 +108,7 @@ module('Unit | Service | auth0', function(hooks) {
       .catch(() => assert.ok(true))
       .finally(done);
 
-    stubbedLock.trigger('unrecoverable_error', new Error());
-  });
-
-  test('showLock rejects when receiving an authorization_error', function(assert) {
-    assert.expect(1);
-    const done = assert.async();
-    const stubbedLock = new StubLock();
-    const subject = this.owner.factoryFor('service:auth0').create({
-      getAuth0LockInstance: this.stubLock(stubbedLock)
-    });
-
-    subject.showLock()
-      .then(() => assert.notOk(true))
-      .catch(() => assert.ok(true))
-      .finally(done);
-
-    stubbedLock.trigger('authorization_error', new Error());
+    stubbedLock.trigger('hide', new Error());
   });
 
   test('showLock rejects when authenticatedData does not exist', function(assert) {


### PR DESCRIPTION
Closes #82 

In addition to fixing the login part, this makes the authentication promise explicitly _reject_ if the user dismisses the Lock. Previously, the promise would just sorta hang in the air forever.

The basic mental model here is that as long as the Lock is visible, the Ember application should treat it as "waiting for user input," regardless of whatever happens on the Lock screen itself. Since `ember-simple-auth` defines promise rejection as "don't start a session," that naturally matches with the Lock getting dismissed.

I'm hoping this won't mess with anyone's workflow, though IMO if someone has some piece of code that checks for promise rejection and treats that as some sort of explicit failure, that code was never properly compatible with this addon in the first place.