### PR TITLE
Don't reject promise when Lock is hidden

### DIFF
--- a/addon/services/auth0.js
+++ b/addon/services/auth0.js
@@ -61,7 +61,6 @@ export default Service.extend({
   },
 
   _setupLock(lock, resolve, reject) {
-    lock.on('hide', reject);
     lock.on('authenticated', (authenticatedData) => {
       if (isEmpty(authenticatedData)) {
         return reject(new Auth0Error('The authenticated data did not come back from the request'));

--- a/tests/unit/services/auth0-test.js
+++ b/tests/unit/services/auth0-test.js
@@ -95,22 +95,6 @@ module('Unit | Service | auth0', function(hooks) {
     stubbedLock.trigger('authenticated', authenticatedData);
   });
 
-  test('showLock rejects when hidden', function(assert) {
-    assert.expect(1);
-    const done = assert.async();
-    const stubbedLock = new StubLock();
-    const subject = this.owner.factoryFor('service:auth0').create({
-      getAuth0LockInstance: this.stubLock(stubbedLock)
-    });
-
-    subject.showLock()
-      .then(() => assert.notOk(true))
-      .catch(() => assert.ok(true))
-      .finally(done);
-
-    stubbedLock.trigger('hide', new Error());
-  });
-
   test('showLock rejects when authenticatedData does not exist', function(assert) {
     assert.expect(1);
     const done = assert.async();


### PR DESCRIPTION
Fixes #133 -- I was kinda iffy about this change anyway. Turns out there's a very legit reason not to do this. Welp!