### PR TITLE
Add native support for Silent Authentication

### DIFF
--- a/addon/authenticators/auth0-base.js
+++ b/addon/authenticators/auth0-base.js
@@ -15,8 +15,7 @@ export default BaseAuthenticator.extend({
     if(expiresAt > now()) {
       return RSVP.resolve(data);
     } else if(get(this, 'auth0.silentAuthOnSessionRestore')) {
-      const options = get(this, 'auth0.silentAuthOptions');
-      return this._performSilentAuth(options)
+      return this._performSilentAuth()
     } else {
       return RSVP.reject();
     }

--- a/addon/authenticators/auth0-base.js
+++ b/addon/authenticators/auth0-base.js
@@ -46,7 +46,15 @@ export default BaseAuthenticator.extend({
       // result of checkSession is the same as parseHash.
       get(this, 'auth0').silentAuth(options).then(authenticatedData => {
         this._resolveAuthResult(authenticatedData, resolve, reject);
-      }, reject);
+      }, result => {
+        // for any error types other than login_required, log it to the console.
+        // otherwise, there are a few cases (auto-renewal, basically) where the
+        // error details will get swallowed completely. Better to give feedback.
+        if(console && result && result.name && result.name !== 'login_required') {
+          console.warn(`Silent authentication failed: ${result.message}`); // eslint-disable-line no-console
+        }
+        reject(result);
+      });
     });
   }
 });

--- a/addon/authenticators/auth0-silent-auth.js
+++ b/addon/authenticators/auth0-silent-auth.js
@@ -1,0 +1,18 @@
+import RSVP from 'rsvp';
+import { get } from '@ember/object';
+import { inject as service } from '@ember/service';
+import Auth0UrlHashAuthenticator from 'ember-simple-auth-auth0/authenticators/auth0-url-hash';
+
+export default Auth0UrlHashAuthenticator.extend({
+  auth0: service(),
+  authenticate(options) {
+    return new RSVP.Promise((resolve, reject) => {
+      // perform silent auth via auth0's checkSession function (called in the service);
+      // if successful, use the same logic as the url-hash authenticator since the
+      // result of checkSession is the same as parseHash.
+      get(this, 'auth0').silentAuth(options).then(authenticatedData => {
+        this._resolveAuthResult(authenticatedData, resolve, reject);
+      }, reject);
+    });
+  }
+});

--- a/addon/authenticators/auth0-silent-auth.js
+++ b/addon/authenticators/auth0-silent-auth.js
@@ -1,18 +1,9 @@
-import RSVP from 'rsvp';
-import { get } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Auth0UrlHashAuthenticator from 'ember-simple-auth-auth0/authenticators/auth0-url-hash';
 
 export default Auth0UrlHashAuthenticator.extend({
   auth0: service(),
   authenticate(options) {
-    return new RSVP.Promise((resolve, reject) => {
-      // perform silent auth via auth0's checkSession function (called in the service);
-      // if successful, use the same logic as the url-hash authenticator since the
-      // result of checkSession is the same as parseHash.
-      get(this, 'auth0').silentAuth(options).then(authenticatedData => {
-        this._resolveAuthResult(authenticatedData, resolve, reject);
-      }, reject);
-    });
+    return this._performSilentAuth(options);
   }
 });

--- a/addon/authenticators/auth0-url-hash.js
+++ b/addon/authenticators/auth0-url-hash.js
@@ -11,19 +11,26 @@ export default Auth0BaseAuthenticator.extend({
   session: service(),
   authenticate(urlHashData) {
     return new RSVP.Promise((resolve, reject) => {
-      if (isEmpty(urlHashData)) {
-        reject();
-      }
-      const auth0 = get(this, 'auth0').getAuth0Instance();
-      const getUserInfo = auth0.client.userInfo.bind(auth0.client);
-
-      getUserInfo(urlHashData.accessToken, (err, profile) => {
-        if (err) {
-          return reject(new Auth0Error(err));
-        }
-
-        resolve(createSessionDataObject(profile, urlHashData));
-      });
+      this._resolveAuthResult(urlHashData, resolve, reject);
     });
   },
+
+  // resolve the data returned by a parseHash/silentAuth result.
+  // this is split into its own function since the silent-auth
+  // authenticator uses it as well.
+  _resolveAuthResult(authResult, resolve, reject) {
+    if (isEmpty(authResult)) {
+      reject();
+    }
+    const auth0 = get(this, 'auth0').getAuth0Instance();
+    const getUserInfo = auth0.client.userInfo.bind(auth0.client);
+
+    getUserInfo(authResult.accessToken, (err, profile) => {
+      if (err) {
+        return reject(new Auth0Error(err));
+      }
+
+      resolve(createSessionDataObject(profile, authResult));
+    });
+  }
 });

--- a/addon/authenticators/auth0-url-hash.js
+++ b/addon/authenticators/auth0-url-hash.js
@@ -1,10 +1,6 @@
 import RSVP from 'rsvp';
-import { get } from '@ember/object';
 import { inject as service } from '@ember/service';
-import { isEmpty } from '@ember/utils';
 import Auth0BaseAuthenticator from 'ember-simple-auth-auth0/authenticators/auth0-base';
-import createSessionDataObject from '../utils/create-session-data-object';
-import { Auth0Error } from '../utils/errors'
 
 export default Auth0BaseAuthenticator.extend({
   auth0: service(),
@@ -12,25 +8,6 @@ export default Auth0BaseAuthenticator.extend({
   authenticate(urlHashData) {
     return new RSVP.Promise((resolve, reject) => {
       this._resolveAuthResult(urlHashData, resolve, reject);
-    });
-  },
-
-  // resolve the data returned by a parseHash/silentAuth result.
-  // this is split into its own function since the silent-auth
-  // authenticator uses it as well.
-  _resolveAuthResult(authResult, resolve, reject) {
-    if (isEmpty(authResult)) {
-      reject();
-    }
-    const auth0 = get(this, 'auth0').getAuth0Instance();
-    const getUserInfo = auth0.client.userInfo.bind(auth0.client);
-
-    getUserInfo(authResult.accessToken, (err, profile) => {
-      if (err) {
-        return reject(new Auth0Error(err));
-      }
-
-      resolve(createSessionDataObject(profile, authResult));
     });
   }
 });

--- a/addon/mixins/application-route-mixin.js
+++ b/addon/mixins/application-route-mixin.js
@@ -99,7 +99,10 @@ export default Mixin.create(ApplicationRouteMixin, {
       return;
     }
 
-    this._scheduleExpire();
+    // [XA] only actually schedule expired events if we're authenticated.
+    if (get(this, 'session.isAuthenticated')) {
+      this._scheduleExpire();
+    }
   },
 
   _scheduleExpire() {

--- a/addon/mixins/application-route-mixin.js
+++ b/addon/mixins/application-route-mixin.js
@@ -114,7 +114,7 @@ export default Mixin.create(ApplicationRouteMixin, {
 
   /**
    * The current JWT's expire time
-   * @return {Number in seconds}
+   * @return {Date of expiration}
    */
   _expiresAt: computed('session.data.authenticated', {
     get() {
@@ -127,6 +127,10 @@ export default Mixin.create(ApplicationRouteMixin, {
     }
   }),
 
+  /**
+   * Number of seconds until the JWT expires.
+   * @return {Number in seconds}
+   */
   _jwtRemainingTimeInSeconds: computed('_expiresAt', {
     get() {
       let remaining = getWithDefault(this, '_expiresAt', 0) - now();

--- a/addon/mixins/application-route-mixin.js
+++ b/addon/mixins/application-route-mixin.js
@@ -74,7 +74,7 @@ export default Mixin.create(ApplicationRouteMixin, {
 
   _getUrlHashData() {
     const auth0 = get(this, 'auth0').getAuth0Instance();
-    const enableImpersonation = !!get(this, 'auth0.config.enableImpersonation');
+    const enableImpersonation = get(this, 'auth0.enableImpersonation');
     return new RSVP.Promise((resolve, reject) => {
       auth0.parseHash({__enableImpersonation: enableImpersonation}, (err, parsedPayload) => {
         if (err) {

--- a/addon/services/auth0.js
+++ b/addon/services/auth0.js
@@ -46,7 +46,40 @@ export default Service.extend({
    */
   domain: readOnly('config.domain'),
 
+  /**
+   * The URL to return to when logging out
+   * @type {String}
+   */
   logoutReturnToURL: readOnly('config.logoutReturnToURL'),
+
+  /**
+   * Perform Silent Authentication with Auth0's checkSession() method.
+   * Returns the authenticated data if successful, or rejects if not.
+   * 
+   * This method does NOT actually create an ember-simple-auth session;
+   * use the authenticator rather than calling this directly.
+   *
+   * @method silentAuth
+   */
+  silentAuth(options) {
+    return new RSVP.Promise((resolve, reject) => {
+      const auth0 = this.getAuth0Instance();
+      auth0.checkSession(options, (err, data) => {
+        if(!err) {
+          // special check: running this with Ember Inspector active
+          // results in an ember version object getting returned for
+          // some oddball reason. Reject and warn the user (dev?).
+          if(data && get(data, 'type') === 'emberVersion') {
+            reject(new Auth0Error('Silent Authentication is not supported when Ember Inspector is enabled. Please disable the extension to re-enable support.'));
+          } else {
+            resolve(data);
+          }
+        } else {
+          reject(new Auth0Error(err));
+        }
+      });
+    });
+  },
 
   showLock(options, clientID = null, domain = null, passwordless = false) {
     return new RSVP.Promise((resolve, reject) => {

--- a/addon/services/auth0.js
+++ b/addon/services/auth0.js
@@ -62,6 +62,12 @@ export default Service.extend({
   silentAuthOnSessionRestore: bool('config.silentAuth.onSessionRestore'),
 
   /**
+   * Automatically perform silent authentication on session expiration.
+   * @type {bool}
+   */
+  silentAuthOnSessionExpire: bool('config.silentAuth.onSessionExpire'),
+
+  /**
    * Options to use when automatically performing silent authentication.
    * @type {Object}
    */
@@ -91,6 +97,9 @@ export default Service.extend({
    * @method silentAuth
    */
   silentAuth(options) {
+    if(!options) {
+      options = get(this, 'silentAuthOptions');
+    }
     return new RSVP.Promise((resolve, reject) => {
       const auth0 = this.getAuth0Instance();
       auth0.checkSession(options, (err, data) => {

--- a/addon/services/auth0.js
+++ b/addon/services/auth0.js
@@ -56,6 +56,12 @@ export default Service.extend({
   logoutReturnToURL: readOnly('config.logoutReturnToURL'),
 
   /**
+   * Enable user impersonation. This is opt-in due to security risks.
+   * @type {bool}
+   */
+  enableImpersonation: bool('config.enableImpersonation'),
+
+  /**
    * Automatically perform silent authentication on session restore.
    * @type {bool}
    */

--- a/addon/services/auth0.js
+++ b/addon/services/auth0.js
@@ -62,6 +62,12 @@ export default Service.extend({
   enableImpersonation: bool('config.enableImpersonation'),
 
   /**
+   * Number of seconds between auto-renewing token via silent authentication.
+   * @type {number}
+   */
+  silentAuthRenewSeconds: readOnly('config.silentAuth.renewSeconds'),
+
+  /**
    * Automatically perform silent authentication on session restore.
    * @type {bool}
    */

--- a/addon/services/auth0.js
+++ b/addon/services/auth0.js
@@ -74,14 +74,16 @@ export default Service.extend({
   silentAuthOnSessionExpire: bool('config.silentAuth.onSessionExpire'),
 
   /**
-   * Options to use when automatically performing silent authentication.
-   * @type {Object}
+   * Default options to use when performing silent authentication.
+   * This is a function rather than a computed property since the
+   * default redirectUri needs to be regenerated every time.
+   * @return {Object}
    */
-  silentAuthOptions: computed(function() {
+  getSilentAuthOptions() {
     const defaultOptions = {
       responseType: 'token',
       scope: 'openid',
-      redirectUri: window.location.origin, // TODO: regenerate this every time
+      redirectUri: window.location.origin,
       timeout: 5000
     };
     const configOptions = getWithDefault(this, 'config.silentAuth.options', {});
@@ -91,7 +93,7 @@ export default Service.extend({
     assign(options, defaultOptions);
     assign(options, configOptions);
     return options;
-  }),
+  },
 
   /**
    * Perform Silent Authentication with Auth0's checkSession() method.
@@ -104,7 +106,7 @@ export default Service.extend({
    */
   silentAuth(options) {
     if(!options) {
-      options = get(this, 'silentAuthOptions');
+      options = this.getSilentAuthOptions();
     }
     return new RSVP.Promise((resolve, reject) => {
       const auth0 = this.getAuth0Instance();

--- a/addon/utils/errors.js
+++ b/addon/utils/errors.js
@@ -4,12 +4,13 @@ export function Auth0Error(payload) {
   let message = 'Auth0 operation failed'
 
   if(typeof payload === 'object' && payload !== null) {
-    if (payload.errorDescription) {
-      payload.errorDescription = decodeURI(payload.errorDescription);
+    if (payload.error_description) {
+      payload.error_description = decodeURI(payload.error_description);
     }
     const errorCode = payload.error || 'unknown'
-    const errorDesc = payload.errorDescription || message
+    const errorDesc = payload.error_description || message
     message = `Auth0 returned error \`${errorCode}\`: ${errorDesc}`
+    this.name = errorCode;
   } else if(typeof payload === 'string') {
     message += `: ${payload}`
     payload = {}

--- a/app/authenticators/auth0-silent-auth.js
+++ b/app/authenticators/auth0-silent-auth.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-simple-auth-auth0/authenticators/auth0-silent-auth';


### PR DESCRIPTION
Adds Silent Authentication support. In addition to adding an `auth0-silent-auth` authenticator, this also adds a few flags to enable automatic token renewal in various ways.

This is all opt-in via `environment.js`, so here's an example configuration hash with all the various options enabled:
```js
// config/environment.js
module.exports = function(environment) {
  let ENV = {
    'ember-simple-auth': {
      // ...

      auth0: {
        // ...

        silentAuth: {

          // automatically renew token every 30 minutes:
          renewSeconds: 1800,

          // automatically renew token when trying to restore an expired session (on app load):
          onSessionRestore: true,

          // automatically renew token when token expiration time is hit (during app use):
          onSessionExpire: true,

          // options to pass to checkSession when doing automatic silent auth.
          // The redirectUri parameter is automatically set to window.location.origin
          // if not specified.
          options: {
            responseType: 'token id_token',
            scope: 'openid profile email',
            timeout: 5000
          }
        }
      }
    }
  };

  return ENV;
};
```

I'm not super-attached to the `renewSeconds` name, so feel free to suggest alternatives. Or any in general -- naming things is hard!