### PR TITLE
Added logoutReturnToPath config option for root-relative logout URL support

### DIFF
--- a/addon/services/auth0.js
+++ b/addon/services/auth0.js
@@ -53,7 +53,14 @@ export default Service.extend({
    * The URL to return to when logging out
    * @type {String}
    */
-  logoutReturnToURL: readOnly('config.logoutReturnToURL'),
+  logoutReturnToURL: computed('config.{logoutReturnToURL,logoutReturnToPath}', function() {
+    const logoutReturnToPath = get(this, 'config.logoutReturnToPath');
+    if (logoutReturnToPath) {
+      assert('ember-simple-auth-auth0 logoutReturnToPath must start with /', logoutReturnToPath.startsWith('/'));
+      return window.location.origin + logoutReturnToPath;
+    }
+    return get(this, 'config.logoutReturnToURL');
+  }),
 
   /**
    * Enable user impersonation. This is opt-in due to security risks.

--- a/tests/unit/services/auth0-test.js
+++ b/tests/unit/services/auth0-test.js
@@ -69,6 +69,20 @@ module('Unit | Service | auth0', function(hooks) {
       config['ember-simple-auth'].auth0.logoutReturnToURL);
   });
 
+  test('it calculates the logoutURL from logoutReturnToPath correctly', function(assert) {
+    const config = this.registerConfig({
+      ['ember-simple-auth']: {
+        auth0: {
+          logoutReturnToPath: '/my-login'
+        }
+      }
+    });
+
+    let service = this.owner.lookup('service:auth0');
+    let path = config['ember-simple-auth'].auth0.logoutReturnToPath
+    assert.equal(get(service, 'logoutReturnToURL'), `${this.windowLocation()}${path}`);
+  });
+
   test('showLock calls getUserInfo', function(assert) {
     assert.expect(1);
     const done = assert.async();


### PR DESCRIPTION
Inspired by #138, I decided to add a similar `logoutReturnToPath` feature. It's like `logoutReturnToURL`, except it's a relative path to which `window.location.origin` is prepended. Thanks @fotinakis for the idea!