### PR TITLE
Add Authorize method to Auth0 Service

### DIFF
--- a/addon/authorizers/jwt.js
+++ b/addon/authorizers/jwt.js
@@ -1,9 +1,19 @@
 import { isPresent } from '@ember/utils';
 import { debug } from '@ember/debug';
+import { deprecate } from '@ember/application/deprecations';
 import BaseAuthorizer from 'ember-simple-auth/authorizers/base';
 
 export default BaseAuthorizer.extend({
   authorize(sessionData, block) {
+    deprecate(`Ember Simple Auth Auth0: Authorizers are deprecated in Ember Simple Auth. Consider using the 'authorize' method of the auth0 service instead.`,
+      false,
+      {
+        id: 'ember-simple-auth-auth0.jwtAuthorizer',
+        until: '5.0.0',
+        url: 'https://github.com/simplabs/ember-simple-auth#deprecation-of-authorizers',
+      }
+    );
+
     let userToken = sessionData['idToken'];
 
     if (isPresent(userToken)) {

--- a/addon/services/auth0.js
+++ b/addon/services/auth0.js
@@ -1,8 +1,8 @@
 import { readOnly, bool } from '@ember/object/computed';
 import { getOwner } from '@ember/application';
 import { getProperties, get, getWithDefault, computed } from '@ember/object';
-import { assert } from '@ember/debug';
-import { isEmpty } from '@ember/utils';
+import { assert, debug } from '@ember/debug';
+import { isEmpty, isPresent } from '@ember/utils';
 import Service, { inject as service } from '@ember/service';
 import { merge as emberMerge, assign as emberAssign } from '@ember/polyfills';
 import RSVP from 'rsvp';
@@ -145,6 +145,30 @@ export default Service.extend({
         }
       });
     });
+  },
+
+  /**
+   * Creates an authorization header from the session's token and calls
+   * the given function, passing the header name & value as parameters.
+   *
+   * This method exists mainly for convencience, though it serves as a
+   * handy drop-in replacement for the now-deprecated jwtAuthorizer.
+   *
+   * Just like with ember-simple-auth's authorizers, this method will do
+   * nothing if the session is not authenticated.
+   *
+   * @method authorize
+   */
+  authorize(block) {
+    if (get(this, 'session.isAuthenticated')) {
+      const userToken = get(this, 'session.data.authenticated.idToken');
+
+      if (isPresent(userToken)) {
+        block('Authorization', `Bearer ${userToken}`);
+      } else {
+        debug('Could not find idToken in authenticated session data.');
+      }
+    }
   },
 
   showLock(options, clientID = null, domain = null, passwordless = false) {


### PR DESCRIPTION
Since authorizers are getting phased out of `ember-simple-auth`, this PR adds an `authorize` method to the `auth0` service that does basically the same thing.

For instance, the following:
```js
get(this, 'session').authorize('authorizer:jwt', (headerName, headerValue) => {
    // ...
});
```


can be rewritten as:
```js
get(this, 'auth0').authorize((headerName, headerValue) => {
    // ...
});
```

Note that there's one less parameter, since there's no authorizer type concept -- just the one.

This is purely a nice-to-have, but it's nice.