### PR TITLE
update dependencies

### DIFF
--- a/addon/services/auth0.js
+++ b/addon/services/auth0.js
@@ -4,14 +4,12 @@ import { getProperties, get, getWithDefault, computed } from '@ember/object';
 import { assert, debug } from '@ember/debug';
 import { isEmpty, isPresent } from '@ember/utils';
 import Service, { inject as service } from '@ember/service';
-import { merge as emberMerge, assign as emberAssign } from '@ember/polyfills';
+import { assign } from '@ember/polyfills';
 import RSVP from 'rsvp';
 import Auth0 from 'auth0-js';
 import { Auth0Lock, Auth0LockPasswordless } from 'auth0-lock';
 import createSessionDataObject from '../utils/create-session-data-object';
 import { Auth0Error } from '../utils/errors'
-
-const assign = Object.assign || emberAssign || emberMerge;
 
 export default Service.extend({
   session: service(),

--- a/package.json
+++ b/package.json
@@ -73,12 +73,12 @@
     "authorization"
   ],
   "dependencies": {
-    "auth0-js": "^9.3.3",
-    "auth0-lock": "^11.4.0",
-    "ember-auto-import": "^1.0.1",
-    "ember-cli-babel": "^6.6.0",
-    "ember-simple-auth": "^1.6.0",
-    "webpack": "^4.12.1"
+    "auth0-js": "^9.9.1",
+    "auth0-lock": "^11.13.1",
+    "ember-auto-import": "^1.2.19",
+    "ember-cli-babel": "^7.4.0",
+    "ember-simple-auth": "^1.8.1",
+    "webpack": "^4.29.0"
   },
   "resolutions": {
     "**/braces": "^2.3.1"

--- a/tests/dummy/app/controllers/login.js
+++ b/tests/dummy/app/controllers/login.js
@@ -2,11 +2,6 @@ import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
 import { alias } from '@ember/object/computed';
 import { get } from '@ember/object';
-import Ember from 'ember';
-
-const {
-  Logger
-} = Ember;
 
 export default Controller.extend({
   session: service(),
@@ -23,7 +18,8 @@ export default Controller.extend({
       };
 
       get(this, 'session').authenticate('authenticator:auth0-lock-passwordless', lockOptions, () => {
-        Logger.info('Passwordless sent');
+        // eslint-disable-next-line no-console
+        console.log('Passwordless sent');
       });
     }
   }

--- a/tests/dummy/app/routes/protected.js
+++ b/tests/dummy/app/routes/protected.js
@@ -1,16 +1,12 @@
 import Route from '@ember/routing/route';
-import Ember from 'ember';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
-
-const {
-  Logger
-} = Ember;
 
 export default Route.extend(AuthenticatedRouteMixin, {
   authenticationRoute: 'login',
   model() {
     return this.store.findAll('post').catch((err) => {
-      Logger.error(err);
+      // eslint-disable-next-line no-console
+      console.error(err);
     });
   }
 });

--- a/tests/unit/services/auth0-test.js
+++ b/tests/unit/services/auth0-test.js
@@ -42,7 +42,7 @@ module('Unit | Service | auth0', function(hooks) {
     };
 
     this.stubLock = function(stubbedLock) {
-      stubbedLock = stubbedLock || new StubLock();
+      stubbedLock = stubbedLock || StubLock.create();
       return this.stub().returns(stubbedLock);
     };
 
@@ -86,7 +86,7 @@ module('Unit | Service | auth0', function(hooks) {
   test('showLock calls getUserInfo', function(assert) {
     assert.expect(1);
     const done = assert.async();
-    const stubbedLock = new StubLock();
+    const stubbedLock = StubLock.create();
     const profile = {
       user_id: '1',
     };
@@ -112,7 +112,7 @@ module('Unit | Service | auth0', function(hooks) {
   test('showLock rejects when authenticatedData does not exist', function(assert) {
     assert.expect(1);
     const done = assert.async();
-    const stubbedLock = new StubLock();
+    const stubbedLock = StubLock.create();
     const subject = this.owner.factoryFor('service:auth0').create({
       getAuth0LockInstance: this.stubLock(stubbedLock)
     });
@@ -128,7 +128,7 @@ module('Unit | Service | auth0', function(hooks) {
   test('showLock rejects when getUserInfo returns an error', function(assert) {
     assert.expect(1);
     const done = assert.async();
-    const stubbedLock = new StubLock({
+    const stubbedLock = StubLock.create({
       shouldThrowGetUserInfoError: true
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1206,7 +1206,7 @@ atob@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
 
-auth0-js@^9.3.3, auth0-js@^9.9.1:
+auth0-js@^9.9.1:
   version "9.9.1"
   resolved "https://registry.yarnpkg.com/auth0-js/-/auth0-js-9.9.1.tgz#7173c987cfa1dcca1888eddcddd196e94bdf037e"
   dependencies:
@@ -1218,9 +1218,10 @@ auth0-js@^9.3.3, auth0-js@^9.9.1:
     url-join "^4.0.0"
     winchan "^0.2.1"
 
-auth0-lock@^11.4.0:
+auth0-lock@^11.13.1:
   version "11.13.1"
   resolved "https://registry.yarnpkg.com/auth0-lock/-/auth0-lock-11.13.1.tgz#9cdd6eec5c3cfa9a8883937659b52614623c7ec0"
+  integrity sha512-CCIRtxeKh6+KW2ZwpRRlLDrrKUOtXxTMqUBJvudRPxVwdoie8g91XNlugRmKbijPlLX9AwoVzKJQvwv8V86J+g==
   dependencies:
     auth0-js "^9.9.1"
     auth0-password-policies "^1.0.2"
@@ -3748,9 +3749,10 @@ ember-assign-polyfill@~2.4.0:
     ember-cli-babel "^6.6.0"
     ember-cli-version-checker "^2.0.0"
 
-ember-auto-import@^1.0.1:
+ember-auto-import@^1.2.19:
   version "1.2.19"
   resolved "https://registry.yarnpkg.com/ember-auto-import/-/ember-auto-import-1.2.19.tgz#69a2da0d2c16ab88989c51381c415214e85d1af3"
+  integrity sha512-OT7I3zrIAv/rbbYJFZNqfJi/2HpAscjOWOaBPPUj8VkUnY26HlLO6mSzDIkoUOaTAEWiy2GzjenHGj6b9rivxw==
   dependencies:
     "@babel/core" "^7.1.6"
     "@babel/traverse" "^7.1.6"
@@ -3838,9 +3840,10 @@ ember-cli-babel@^6.16.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.8.2:
     ember-cli-version-checker "^2.1.2"
     semver "^5.5.0"
 
-ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.2, ember-cli-babel@^7.1.3:
+ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.2, ember-cli-babel@^7.1.3, ember-cli-babel@^7.4.0:
   version "7.4.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.4.0.tgz#8fc38a650629c0408adf50a46deef91fcd9d0f1d"
+  integrity sha512-nCEniuWcZMZ12uJopHAMEzj0J55fDEKVEr0adoYZNl7e3E6Pz4WyixyddhhzNa+WcOl9ZULYbH/1R0AL4Tyzjg==
   dependencies:
     "@babel/core" "^7.0.0"
     "@babel/plugin-transform-modules-amd" "^7.0.0"
@@ -4405,9 +4408,10 @@ ember-router-generator@^1.2.3:
   dependencies:
     recast "^0.11.3"
 
-ember-simple-auth@^1.6.0:
+ember-simple-auth@^1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/ember-simple-auth/-/ember-simple-auth-1.8.1.tgz#ff2de9a035f0902e9de660e93568e6956da2bdb9"
+  integrity sha512-2LV7RCBYMfc1JbJv00lm0GTx9sBMY4w6pzyOolH71J1MW1d+tahonaV4ZE+/R+TB85PMza0wabFh98Xq9xKaqA==
   dependencies:
     base-64 "^0.1.0"
     broccoli-file-creator "^2.0.0"
@@ -11165,7 +11169,7 @@ webpack-sources@^1.1.0, webpack-sources@^1.3.0:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack@^4.12.0, webpack@^4.12.1:
+webpack@^4.12.0, webpack@^4.29.0:
   version "4.29.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.29.0.tgz#f2cfef83f7ae404ba889ff5d43efd285ca26e750"
   dependencies:


### PR DESCRIPTION
Initially did this PR to update ember-simple-auth dependency.
This was forcing apps to use a previous version which introduce some deprecations on the consuming app.

Also updated the project's dependencies and got rid of some deprecations:
- stop using Ember.merge
- stop using Ember.Logger
- stop using `new` with `EmberObject` subclasses

Also bumped other dependencies.