### PR TITLE
Use accessToken instead of idToken

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,9 +465,9 @@ import { debug } from '@ember/debug';
 
 export default JSONAPIAdapter.extend(DataAdapterMixin, {
   authorize(xhr){
-    const { idToken } = this.get('session.data.authenticated');
-    if (isPresent(idToken)) {
-      xhr.setRequestHeader('Authorization', `Bearer ${idToken}`);
+    const { accessToken } = this.get('session.data.authenticated');
+    if (isPresent(accessToken)) {
+      xhr.setRequestHeader('Authorization', `Bearer ${accessToken}`);
     } else {
       debug('Could not find the authorization token in the session data.');
     }


### PR DESCRIPTION
The access token should be used to communicate with the API and not the id token.
See https://auth0.com/docs/api-auth/tutorials/adoption/api-tokens
For server tech stacks that are very strict on the JWT validation, this will result in an 'audience invalid' error if using the id token.