### PR TITLE
Trigger is not a function.

### DIFF
--- a/addon/services/auth0.js
+++ b/addon/services/auth0.js
@@ -241,7 +241,7 @@ export default Service.extend({
 
     // [XA] shim for tests -- need to wait until the above 'authenticated'
     // listener is registered before triggering it during unit tests.
-    if (this.get('inTesting')) {
+    if (lock.trigger && this.get('inTesting')) {
       lock.trigger('_setupCompleted');
     }
   },


### PR DESCRIPTION
This is an attempt at resolving #182 where I can't log in when in the `test` environment.

I've had a look and `.trigger` seems to be a method in `ember-simple-auth` and not `auth0-js`. 

Perhaps I've configured  `ember-simple-auth-auth0` incorrectly in my application. As I mentioned in #182 this wasn't an issue in `4.2.0`.

