### PR TITLE
fix: failed renew token invalidates session

### DIFF
--- a/addon/mixins/application-route-mixin.js
+++ b/addon/mixins/application-route-mixin.js
@@ -117,6 +117,10 @@ export default Mixin.create(ApplicationRouteMixin, {
   },
 
   _scheduleRenew() {
+    if (!Ember.get(this, 'session.isAuthenticated')) {
+      this.sessionInvalidated();
+    }
+    
     const renewInMilli = this.auth0.silentAuthRenewSeconds * 1000;
     if(renewInMilli) {
       this._scheduleJob('_renewJob', this._processSessionRenewed, renewInMilli);


### PR DESCRIPTION

When using `Silent Authentication`, I found out that it uses `auth0-min.esm.js` to clear previously stored data by removing storage item. i.e.

```javascript
TransactionManager.prototype.clearTransaction = function(state) {
    this.storage.removeItem(this.namespace + state);
}
```

This is almost equivalent to `session.invalidate();` in the addon service, and does not clean after itself like it ought to be. This can result in unexpected behavior in the context of routing, such as not redirecting to the authentication route, (unless use ember observer, which I consider is a band-aid hack).


With the following environment config in place.

```
   'ember-simple-auth': {
      auth0: {
          // for debugging
          renewSeconds: 5, 

          options: {
            responseType: 'token id_token',
            scope: 'openid profile email',
            timeout: 5000,
            redirectPath: '/login'
          }
```

After debugging, I found that 

`_scheduleRenew()` get be called two places in `ember-simple-auth-auth0/mixins/application-route-mixin`, as follows: 

1) 
```javascript
  _processSessionRenewed() {
    // [XA] need to refactor this a bit. This is kinda bonkers-spaghetti right now.
    return this._trySilentAuth()
      .then(this._scheduleRenew.bind(this), this._setupFutureEvents.bind(this));
  }
```

2)

```javascript
  _processSessionExpired() {
    return this.beforeSessionExpired()
      .then(this._trySilentAuth.bind(this))
      .then(this._invalidateIfAuthenticated.bind(this), this._scheduleExpire.bind(this)); // reschedule expiration if we re-authenticate.
  }
```

I found that the fix is that

```
  _scheduleRenew() {
    if (!Ember.get(this, 'session.isAuthenticated')) {
      this.sessionInvalidated();    // <- this is key to notify route needs to be updated
    }
   ...
  }
```

PS: I only tested the renewal case was not working for me, and went ahead fied `1)`. Not sure if the expiring case was working or not working, did not test. But the idea is the same here, we should check  the `session`'s validity when scheduling jobs. If not validated already, then we should call route mixin's `this.sessionInvalidated();` to propagate.